### PR TITLE
Enable RSS feed for post listing

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,6 +3,7 @@ project:
 
 website:
   title: "Acoular"
+  site-url: https://blog.acoular.org
   repo-url: https://github.com/acoular/blog2
   repo-actions: 
     - source

--- a/index.qmd
+++ b/index.qmd
@@ -10,6 +10,7 @@ listing:
   filter-ui: false
   image-placeholder: "logo.png"
   image-height: "100"
+  feed: true
 page-layout: full
 ---
 ## A blog on Acoular - the acoustic testing and source mapping software in Python


### PR DESCRIPTION
## Summary
- Adds `site-url` so generated links/feed URLs are absolute.
- Enables Quarto's built-in `feed: true` on the post listing, generating `index.xml` at `https://blog.acoular.org/index.xml`.

This lets other sites (e.g. the Acoular org homepage at acoular.org) pull the latest post titles/descriptions/links client-side to render blog tiles, without scraping HTML.

## Test plan
- [ ] `quarto render` locally / CI publish workflow succeeds
- [ ] `https://blog.acoular.org/index.xml` is reachable after merge and lists posts with title/description/link