### PR TITLE
Trim RSS feed to partial content

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -10,7 +10,9 @@ listing:
   filter-ui: false
   image-placeholder: "logo.png"
   image-height: "100"
-  feed: true
+  feed:
+    items: 6
+    type: partial
 page-layout: full
 ---
 ## A blog on Acoular - the acoustic testing and source mapping software in Python


### PR DESCRIPTION
Follow-up to #6: \`feed: true\` embedded each post's full rendered HTML in the feed (up to ~175KB/item, ~300KB total). Switches to \`feed: {items: 6, type: partial}\`, truncating each entry at its \`<!--more-->\` marker — feed drops to ~5KB. Verified locally with \`quarto render\`.